### PR TITLE
[Feature] Add dockerfile for Orbdetpy using ubuntu 20.04

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,23 @@
+FROM ubuntu:20.04
+
+# Use --build-arg #.#.# when building to use other version
+ARG JAVA_MAJOR_VERSION=11
+ARG ORBDETPY_VERSION=2.0.7
+
+# Install orbdetpy dependencies
+RUN apt-get update && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+    openjdk-${JAVA_MAJOR_VERSION}-jdk software-properties-common python3-pip python3-venv wget && \
+    add-apt-repository ppa:deadsnakes/ppa
+
+# Install orbdetpy into virtual environment and update orekit-data
+RUN cd && \
+    python3 -m venv env_orbdetpy && \
+    . env_orbdetpy/bin/activate && \
+    pip install orbdetpy==${ORBDETPY_VERSION} ipython && \
+    python -c "from orbdetpy.astro_data import update_data; update_data();"
+
+RUN cd && \
+    wget -qO- https://github.com/ut-astria/orbdetpy/archive/refs/tags/${ORBDETPY_VERSION}.tar.gz | \
+    tar -xvz -C /root/ && \
+    mv orbdet* orbdetpy

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ filter to estimate unmodeled accelerations.
 Installation
 ------------
 
-If you have docker installed and wish to use a pre-build environment, head to the docker section in this README.
+If you have docker installed and wish to use a pre-built environment head to the docker section in this README.
 
 1. Install Java SE 11 (11.0.10) from <https://www.oracle.com/javadownload>.
    Set the `JAVA_HOME` environment variable to the Java installation
@@ -58,7 +58,7 @@ Development
 Docker
 ------
 
-1. Build the docker image on a machine that has docker installed and go to the root folder where the `Dockerfile` is and run, `docker build --build-arg ORBDETPY_VERSION=2.0.7 -t orbdetpy:2.0.7 .`
+1. Build the docker image on a machine that has docker installed and go to the root folder of this repository where the `Dockerfile` is and run, `docker build --build-arg ORBDETPY_VERSION=2.0.7 -t orbdetpy:2.0.7 .`
 
 2. Run *orbdetpy:2.0.7* image in a daemon state: `docker run -it --rm orbdetpy:2.0.7 bash`
 

--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ filter to estimate unmodeled accelerations.
 Installation
 ------------
 
+If you have docker installed and wish to use a pre-build environment, head to the docker section in this README.
+
 1. Install Java SE 11 (11.0.10) from <https://www.oracle.com/javadownload>.
    Set the `JAVA_HOME` environment variable to the Java installation
    folder. The `java` executable must be added to the system path.
@@ -52,6 +54,21 @@ Development
    `mvn -e package`
 
 3. Run `pip install -e ./` from the top-level folder containing `setup.py`.
+
+Docker
+------
+
+1. Build the docker image on a machine that has docker installed and go to the root folder where the `Dockerfile` is and run, `docker build --build-arg ORBDETPY_VERSION=2.0.7 -t orbdetpy:2.0.7 .`
+
+2. Run *orbdetpy:2.0.7* image in a daemon state: `docker run -it --rm orbdetpy:2.0.7 bash`
+
+3. Next we will activate the python environment and run a test to determine a successful docker image build
+
+```bash
+cd && . env_orbdetpy/bin/activate && python orbdetpy/examples/test_estimation.py
+```
+
+4. From here, you can either develop in orbdetpy or build scripts and test in this pre-built environment
 
 Examples
 --------


### PR DESCRIPTION
Added a `Dockerfile` to the root of the repository and build instructions in the `READEME.md`.  When you build the docker image it will install all deps (python 3.8, Java 11, orbdetpy 2.0.7 [unless you change this via the build argument]), create a virtual env where the orbdetpy python package for the specified version is downloaded and update all orekit-data. 

Below is an example of running one of the examples scripts within the docker image. 

```bash
root@67a7d8e612a5:~# cd && . env_orbdetpy/bin/activate && python orbdetpy/examples/test_estimation.py 
2019-05-01T00:00:00.000Z Millstone [-23184132.986156963, 35171149.25144017, 43279.950996453284, -2555.473680268283, -1688.6256073930956, 135.62083133202174]
2019-05-01T00:00:00.000Z Maui [-23183627.17236768, 35169986.54281181, 43513.61483357243, -2555.4774708100663, -1688.608643105383, 135.6166678205704]
2019-05-01T00:05:00.000Z Millstone [-23947760.908920106, 34653170.602586, 84872.11391235465, -2528.1095472537886, -1750.60811667896, 137.80212753113142]
2019-05-01T00:05:00.000Z Maui [-23947646.903615456, 34653038.201017216, 85176.25669550947, -2527.7541786181696, -1751.0141735600514, 138.81030585130955]
2019-05-01T00:10:00.000Z Millstone [-24700189.309338674, 34119592.22854014, 126936.58167590505, -2488.8772426202995, -1805.7772334403012, 138.9225364421567]
2019-05-01T00:10:00.000Z Maui [-24701100.516358867, 34120998.638695486, 126700.32251330567, -2490.4915249308274, -1803.2439870146702, 138.47725666074322]
2019-05-01T00:15:00.000Z Millstone [-25441896.7746508, 33571565.33199155, 168232.13343733322, -2449.933099890072, -1857.7501741981016, 138.26412647757024]
2019-05-01T00:15:00.000Z Maui [-25442728.007228907, 33572813.806774795, 168136.82415573567, -2450.980597767818, -1856.1447950544682, 138.14512965593624]
2019-05-01T00:20:00.000Z Millstone [-26171957.851921853, 33008087.505413577, 209582.94231940832, -2409.791617075451, -1909.2777650525766, 137.89601485403261]
2019-05-01T00:20:00.000Z Maui [-26171503.025391813, 33007434.810423143, 209655.45653547972, -2409.3429765565443, -1909.9348941906792, 137.96981275009864]
2019-05-01T00:25:00.000Z Millstone [-26888621.284457877, 32427208.870148525, 251106.83020005716, -2367.396129533387, -1961.8284124224576, 137.71709453567908]
2019-05-01T00:25:00.000Z Maui [-26888217.529535074, 32426644.26182447, 251120.58554173494, -2367.0654476415903, -1962.30144131497, 137.72541222875802]
2019-05-01T00:26:02.853Z  [-27036710.96559492, 32302966.60772507, 259774.36632136727, -2358.028845896472, -1973.1491123836536, 137.63982402980525]
2019-05-01T00:27:02.853Z  [-27177932.740599796, 32184267.977398276, 268030.2367187015, -2349.3561313705904, -1983.4655600793362, 137.5554156367237]
2019-05-01T00:28:02.853Z  [-27318632.800289605, 32064951.50310752, 276280.9633853618, -2340.638363382656, -1993.7438782013267, 137.46836662396072]
2019-05-01T00:29:02.853Z  [-27458808.44650305, 31945019.47855658, 284526.38793546066, -2331.875710288992, -2003.9838692259145, 137.37867870687944]
2019-05-01T00:30:00.000Z Millstone [-27591492.108572394, 31829959.944271315, 292365.8618398406, -2323.2519520584055, -2013.8528302192829, 137.27550245695494]
2019-05-01T00:30:00.000Z Maui [-27591365.19195494, 31829797.263253223, 292431.189257744, -2323.1533750836006, -2013.9810169340128, 137.33168118561375]
2019-05-01T00:30:02.853Z  [-27597992.54952277, 31824050.684802175, 292822.9901864802, -2322.733562648911, -2014.4652361842684, 137.32723050890365]
2019-05-01T00:35:00.000Z Maui [-28281369.826240268, 31217661.251362506, 333582.217660754, -2278.2739323231526, -2064.67082527559, 136.84848818328862]
2019-05-01T00:40:00.000Z Maui [-28957872.324670248, 30590634.282797657, 374550.18872286857, -2232.4001368980807, -2114.234333953919, 136.27946116030895]
2019-05-01T00:45:00.000Z Maui [-29621269.887968935, 29949954.301018532, 415261.43148742913, -2185.9268416634204, -2162.146634243218, 135.60133527504297]
2019-05-01T00:50:00.000Z Maui [-30269796.567719284, 29294062.032956988, 455898.8495648783, -2137.97650538145, -2209.595415531347, 134.93622937424178]
2019-05-01T00:55:00.000Z Maui [-30903512.303484898, 28623767.131855506, 496375.1403252631, -2088.8793342559175, -2256.1360811811696, 134.22640426650582]
2019-05-01T01:00:00.000Z Maui [-31522513.671882328, 27939883.088779617, 536572.44195287, -2038.8652099782976, -2301.481670655846, 133.42293481078255]
```

Versions installed in orbdetpy image based on an ubuntu:20.04 image:

```bash
(env_orbdetpy) root@67a7d8e612a5:~# java --version
openjdk 11.0.13 2021-10-19
OpenJDK Runtime Environment (build 11.0.13+8-Ubuntu-0ubuntu1.20.04)
OpenJDK 64-Bit Server VM (build 11.0.13+8-Ubuntu-0ubuntu1.20.04, mixed mode, sharing)
```

```bash
(env_orbdetpy) root@67a7d8e612a5:~# python --version
Python 3.8.10 #default for ubuntu 20.04 python3 installed
```

```bash
(env_orbdetpy) root@67a7d8e612a5:~# python -c "import orbdetpy; print(orbdetpy.__version__)"
2.0.7
```
